### PR TITLE
Add MatterSim-v1.0.0-1M results

### DIFF
--- a/models/MatterSim-v1.0.0-1M/1_test_srme.py
+++ b/models/MatterSim-v1.0.0-1M/1_test_srme.py
@@ -1,0 +1,300 @@
+import os
+import datetime
+import warnings
+from typing import Literal, Any
+from collections.abc import Callable
+import traceback
+from copy import deepcopy
+from importlib.metadata import version
+import json
+
+import pandas as pd
+
+from tqdm import tqdm
+
+from ase.constraints import FixSymmetry
+from ase.filters import ExpCellFilter, FrechetCellFilter
+from ase.optimize import FIRE, LBFGS
+from ase.optimize.optimize import Optimizer
+from ase import Atoms
+from ase.io import read
+
+from k_srme import aseatoms2str, two_stage_relax, ID, STRUCTURES, NO_TILT_MASK
+from k_srme.utils import symm_name_map, get_spacegroup_number, check_imaginary_freqs
+from k_srme.conductivity import (
+    init_phono3py,
+    get_fc2_and_freqs,
+    get_fc3,
+    calculate_conductivity,
+)
+
+from mattersim.forcefield import MatterSimCalculator
+import torch
+
+warnings.filterwarnings("ignore", category=DeprecationWarning, module="spglib")
+
+
+# EDITABLE CONFIG
+model_name = "MatterSim"
+checkpoint = "MatterSim-v1.0.0-1M.pth"
+
+device = "cuda" if torch.cuda.is_available() else "cpu"
+calc = MatterSimCalculator(load_path=checkpoint, device=device)
+
+# Relaxation parameters
+ase_optimizer: Literal["FIRE", "LBFGS", "BFGS"] = "FIRE"
+ase_filter: Literal["frechet", "exp"] = "frechet"
+if_two_stage_relax = True  # Use two-stage relaxation enforcing symmetries
+max_steps = 300
+force_max = 1e-4  # Run until the forces are smaller than this in eV/A
+
+# Symmetry parameters
+# symmetry precision for enforcing relaxation and conductivity calculation
+symprec = 1e-5
+# Enforce symmetry with during relaxation if broken
+enforce_relax_symm = True
+# Conductivity to be calculated if symmetry group changed during relaxation
+conductivity_broken_symm = False
+prog_bar = True
+save_forces = True  # Save force sets to file
+
+
+slurm_array_task_count = int(
+    os.getenv(
+        "K_SRME_RESTART_ARRAY_TASK_COUNT", os.getenv("SLURM_ARRAY_TASK_COUNT", "1")
+    )
+)
+slurm_array_task_id = int(os.getenv("SLURM_ARRAY_TASK_ID", "0"))
+slurm_array_job_id = os.getenv("SLURM_ARRAY_JOB_ID", os.getenv("SLURM_JOB_ID", "debug"))
+slurm_array_task_min = int(
+    os.getenv("K_SRME_RESTART_ARRAY_TASK_MIN", os.getenv("SLURM_ARRAY_TASK_MIN", "0"))
+)
+
+
+task_type = "LTC"  # lattice thermal conductivity
+job_name = f"{model_name}-phononDB-{task_type}-{ase_optimizer}{'_2SR' if if_two_stage_relax else ''}_force{force_max}_sym{symprec}"
+module_dir = os.path.dirname(__file__)
+out_dir = os.getenv(
+    "SBATCH_OUTPUT",
+    f"{module_dir}/{datetime.datetime.now().strftime('%Y-%m-%d')}-{job_name}",
+)
+os.makedirs(out_dir, exist_ok=True)
+
+out_path = (
+    f"{out_dir}/conductivity_{slurm_array_job_id}-{slurm_array_task_id:>03}.json.gz"
+)
+
+
+timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+struct_data_path = STRUCTURES
+print(f"\nJob {job_name} started {timestamp}")
+
+
+print(f"Read data from {struct_data_path}")
+atoms_list: list[Atoms] = read(struct_data_path, format="extxyz", index=":")
+
+run_params = {
+    "timestamp": timestamp,
+    "k_srme_version": version("k_srme"),
+    "model_name": model_name,
+    "checkpoint": checkpoint,
+    "device": device,
+    "versions": {dep: version(dep) for dep in ("numpy", "torch")},
+    "ase_optimizer": ase_optimizer,
+    "ase_filter": ase_filter,
+    "if_two_stage_relax": if_two_stage_relax,
+    "max_steps": max_steps,
+    "force_max": force_max,
+    "symprec": symprec,
+    "enforce_relax_symm": enforce_relax_symm,
+    "conductivity_broken_symm": conductivity_broken_symm,
+    "slurm_array_task_count": slurm_array_task_count,
+    "slurm_array_job_id": slurm_array_job_id,
+    "task_type": task_type,
+    "job_name": job_name,
+    "struct_data_path": os.path.basename(struct_data_path),
+    "n_structures": len(atoms_list),
+}
+
+if slurm_array_task_id == slurm_array_task_min:
+    with open(f"{out_dir}/run_params.json", "w") as f:
+        json.dump(run_params, f, indent=4)
+
+if slurm_array_job_id == "debug":
+    atoms_list = atoms_list[:5]
+    print("Running in DEBUG mode.")
+elif slurm_array_task_count > 1:
+    # Split the atoms_list into slurm_array_task_count parts trying to make even runtime
+    atoms_list = atoms_list[
+        slurm_array_task_id - slurm_array_task_min :: slurm_array_task_count
+    ]
+
+
+# Set up the relaxation and force set calculation
+filter_cls: Callable[[Atoms], Atoms] = {
+    "frechet": FrechetCellFilter,
+    "exp": ExpCellFilter,
+}[ase_filter]
+optim_cls: Callable[..., Optimizer] = {"FIRE": FIRE, "LBFGS": LBFGS}[ase_optimizer]
+
+
+force_results: dict[str, dict[str, Any]] = {}
+kappa_results: dict[str, dict[str, Any]] = {}
+
+
+tqdm_bar = tqdm(atoms_list, desc="Conductivity calculation: ", disable=not prog_bar)
+
+for atoms in tqdm_bar:
+    mat_id = atoms.info[ID]
+    init_info = deepcopy(atoms.info)
+    mat_name = atoms.info["name"]
+    mat_desc = f"{mat_name}-{symm_name_map[atoms.info['symm.no']]}"
+    info_dict = {
+        "desc": mat_desc,
+        "name": mat_name,
+        "initial_space_group_number": atoms.info["symm.no"],
+        "errors": [],
+        "error_traceback": [],
+    }
+
+    tqdm_bar.set_postfix_str(mat_desc, refresh=True)
+
+    # Relaxation
+    try:
+        atoms.calc = calc
+        if max_steps > 0:
+            if not if_two_stage_relax:
+                if enforce_relax_symm:
+                    atoms.set_constraint(FixSymmetry(atoms))
+                    filtered_atoms = filter_cls(atoms, mask=NO_TILT_MASK)
+                else:
+                    filtered_atoms = filter_cls(atoms)
+
+                optimizer = optim_cls(
+                    filtered_atoms, logfile=f"{out_dir}/relax_{slurm_array_task_id}.log"
+                )
+                optimizer.run(fmax=force_max, steps=max_steps)
+
+                reached_max_steps = False
+                if optimizer.step == max_steps:
+                    reached_max_steps = True
+                    print(
+                        f"Material {mat_desc=}, {mat_id=} reached max step {max_steps=} during relaxation."
+                    )
+
+                # maximum residual stress component in for xx,yy,zz and xy,yz,xz components separately
+                # result is a array of 2 elements
+                max_stress = atoms.get_stress().reshape((2, 3), order="C").max(axis=1)
+
+                atoms.calc = None
+                atoms.constraints = None
+                atoms.info = init_info | atoms.info
+
+                symm_no = get_spacegroup_number(atoms, symprec=symprec)
+
+                relax_dict = {
+                    "structure": aseatoms2str(atoms),
+                    "max_stress": max_stress,
+                    "reached_max_steps": reached_max_steps,
+                    "relaxed_space_group_number": symm_no,
+                    "broken_symmetry": symm_no
+                    != init_info["initial_space_group_number"],
+                }
+
+            else:
+                atoms, relax_dict = two_stage_relax(
+                    atoms,
+                    fmax_stage1=force_max,
+                    fmax_stage2=force_max,
+                    steps_stage1=max_steps,
+                    steps_stage2=max_steps,
+                    Optimizer=optim_cls,
+                    Filter=filter_cls,
+                    allow_tilt=False,
+                    log=f"{out_dir}/relax_{slurm_array_task_id}.log",
+                    enforce_symmetry=enforce_relax_symm,
+                )
+
+                atoms.calc = None
+
+    except Exception as exc:
+        warnings.warn(f"Failed to relax {mat_name=}, {mat_id=}: {exc!r}")
+        traceback.print_exc()
+        info_dict["errors"].append(f"RelaxError: {exc!r}")
+        info_dict["error_traceback"].append(traceback.format_exc())
+        kappa_results[mat_id] = info_dict
+        continue
+
+    # Calculation of force sets
+    try:
+        ph3 = init_phono3py(atoms, log=False, symprec=symprec)
+
+        ph3, fc2_set, freqs = get_fc2_and_freqs(
+            ph3,
+            calculator=calc,
+            log=False,
+            pbar_kwargs={"leave": False, "disable": not prog_bar},
+        )
+
+        imaginary_freqs = check_imaginary_freqs(freqs)
+        freqs_dict = {"imaginary_freqs": imaginary_freqs, "frequencies": freqs}
+
+        # if conductivity condition is met, calculate fc3
+        ltc_condition = not imaginary_freqs and (
+            not relax_dict["broken_symmetry"] or conductivity_broken_symm
+        )
+
+        if ltc_condition:
+            ph3, fc3_set = get_fc3(
+                ph3,
+                calculator=calc,
+                log=False,
+                pbar_kwargs={"leave": False, "disable": not prog_bar},
+            )
+
+        else:
+            fc3_set = []
+
+        if save_forces:
+            force_results[mat_id] = {"fc2_set": fc2_set, "fc3_set": fc3_set}
+
+        if not ltc_condition:
+            kappa_results[mat_id] = info_dict | relax_dict | freqs_dict
+            continue
+
+    except Exception as exc:
+        warnings.warn(f"Failed to calculate force sets {mat_id}: {exc!r}")
+        traceback.print_exc()
+        info_dict["errors"].append(f"ForceConstantError: {exc!r}")
+        info_dict["error_traceback"].append(traceback.format_exc())
+        kappa_results[mat_id] = info_dict | relax_dict
+        continue
+
+    # Calculation of conductivity
+    try:
+        ph3, kappa_dict = calculate_conductivity(ph3, log=False)
+
+    except Exception as exc:
+        warnings.warn(f"Failed to calculate conductivity {mat_id}: {exc!r}")
+        traceback.print_exc()
+        info_dict["errors"].append(f"ConductivityError: {exc!r}")
+        info_dict["error_traceback"].append(traceback.format_exc())
+        kappa_results[mat_id] = info_dict | relax_dict | freqs_dict
+        continue
+
+    kappa_results[mat_id] = info_dict | relax_dict | freqs_dict | kappa_dict
+
+
+df_kappa = pd.DataFrame(kappa_results).T
+df_kappa.index.name = ID
+df_kappa.reset_index().to_json(out_path)
+
+
+if save_forces:
+    force_out_path = (
+        f"{out_dir}/force_sets_{slurm_array_job_id}-{slurm_array_task_id:>03}.json.gz"
+    )
+    df_force = pd.DataFrame(force_results).T
+    df_force = pd.concat([df_kappa, df_force], axis=1)
+    df_force.index.name = ID
+    df_force.reset_index().to_json(force_out_path)

--- a/models/MatterSim-v1.0.0-1M/2024-12-05-MatterSim-phononDB-LTC-FIRE_2SR_force0.0001_sym1e-05/run_params.json
+++ b/models/MatterSim-v1.0.0-1M/2024-12-05-MatterSim-phononDB-LTC-FIRE_2SR_force0.0001_sym1e-05/run_params.json
@@ -1,0 +1,25 @@
+{
+    "timestamp": "2024-12-05 11:38:28",
+    "k_srme_version": "1.0.0",
+    "model_name": "MatterSim",
+    "checkpoint": "MatterSim-v1.0.0-1M.pth",
+    "device": "cpu",
+    "versions": {
+        "numpy": "1.26.4",
+        "torch": "2.2.0"
+    },
+    "ase_optimizer": "FIRE",
+    "ase_filter": "frechet",
+    "if_two_stage_relax": true,
+    "max_steps": 300,
+    "force_max": 0.0001,
+    "symprec": 1e-05,
+    "enforce_relax_symm": true,
+    "conductivity_broken_symm": false,
+    "slurm_array_task_count": 33,
+    "slurm_array_job_id": "8242268",
+    "task_type": "LTC",
+    "job_name": "MatterSim-phononDB-LTC-FIRE_2SR_force0.0001_sym1e-05",
+    "struct_data_path": "phononDB-PBE-structures.extxyz",
+    "n_structures": 103
+}

--- a/models/MatterSim-v1.0.0-1M/2_evaluate.py
+++ b/models/MatterSim-v1.0.0-1M/2_evaluate.py
@@ -1,0 +1,92 @@
+import os
+from glob import glob
+import pandas as pd
+
+from k_srme import glob2df, ID, DFT_NONAC_REF
+from k_srme.benchmark import get_metrics, process_benchmark_descriptors
+
+
+model_name = "MatterSim"
+
+json_file = "k_srme.json.gz"
+txt_path = "metrics.txt"
+in_file = "conductivity_*-???.json.gz"
+
+in_folder = f"2024-12-05-{model_name}-phononDB-LTC-FIRE_2SR_force0.0001_sym1e-05/"
+
+# Comparing with the DFT results without
+# non-analytical correction term (NAC)
+DFT_RESULTS_FILE = DFT_NONAC_REF
+
+
+module_dir = os.path.dirname(__file__)
+in_pattern = f"{module_dir}/{in_folder}/{in_file}"
+out_path = f"{module_dir}/{in_folder}/{json_file}"
+
+
+# Read MLP results
+if not glob(in_pattern):
+    if os.path.exists(out_path):
+        df_mlp_results = pd.read_json(out_path).set_index(ID)
+else:
+    df_mlp_results = glob2df(in_pattern, max_files=None).set_index(ID)
+
+
+# df_mlp_results.reset_index().to_json(out_path)
+
+# Read DFT results
+df_dft_results = pd.read_json(DFT_RESULTS_FILE).set_index(ID)
+
+
+df_mlp_filtered = df_mlp_results[df_mlp_results.index.isin(df_dft_results.index)]
+df_mlp_filtered = df_mlp_filtered.reindex(df_dft_results.index)
+
+df_mlp_processed = process_benchmark_descriptors(df_mlp_filtered, df_dft_results)
+
+mSRE, mSRME, rmseSRE, rmseSRME = get_metrics(df_mlp_filtered)
+
+
+# Save results
+df_mlp_processed.round(5)
+df_mlp_processed.index.name = ID
+df_mlp_processed.reset_index().to_json(out_path)
+
+
+# Print
+pd.set_option("display.max_rows", None)
+pd.set_option("display.max_columns", None)
+df_mlp_print = df_mlp_filtered[
+    [
+        "desc",
+        "SRME",
+        "SRE",
+        "kappa_TOT_ave",
+        "DFT_kappa_TOT_ave",
+        "imaginary_freqs",
+        "errors",
+    ]
+]
+df_mlp_print["DFT_kappa_TOT_ave"] = df_mlp_print["DFT_kappa_TOT_ave"].apply(
+    lambda x: x[0] if not pd.isna(x) else x
+)
+df_mlp_print["kappa_TOT_ave"] = df_mlp_print["kappa_TOT_ave"].apply(
+    lambda x: x[0] if not pd.isna(x) else x
+)
+df_mlp_print["SRME_failed"] = df_mlp_print["SRME"].apply(lambda x: x == 2)
+
+with open(txt_path, "w") as f:
+    print(f"MODEL: {model_name}", file=f)
+    print(f"\tmean SRME: {mSRME}", file=f)
+    print(f"\tmean SRE: {mSRE}", file=f)
+
+    print(df_mlp_print.round(4), file=f)
+
+
+df_mlp_print = df_mlp_print[
+    ["desc", "SRME", "SRE", "kappa_TOT_ave", "DFT_kappa_TOT_ave"]
+]
+print(df_mlp_print.round(3))
+
+print(f"MODEL: {model_name}")
+print(f"\tmean SRME: {mSRME}")
+print(f"\tmean SRE: {mSRE}")

--- a/models/MatterSim-v1.0.0-1M/metrics.txt
+++ b/models/MatterSim-v1.0.0-1M/metrics.txt
@@ -1,0 +1,214 @@
+MODEL: MatterSim
+	mean SRME: 0.5545498749591197
+	mean SRE: 0.34254858903760177
+               desc    SRME     SRE  kappa_TOT_ave  DFT_kappa_TOT_ave  \
+mp_id                                                                   
+mp-2472      SrO-rs  0.2380  0.0213         9.7062             9.9151   
+mp-2542      BeO-wz  0.1224  0.0619       275.2448           292.8383   
+mp-8884     ZnTe-wz  0.6220  0.1243        14.1247            15.9969   
+mp-1541     BeSe-zb  0.3405  0.2755        73.8029            97.3876   
+mp-23295    RbCl-rs  1.1656  1.1111         0.5661             1.9815   
+mp-23703     LiH-rs  0.6614  0.6408        11.0303            21.4309   
+mp-1183441  BeTe-wz  0.4895  0.1864        53.4015            64.3781   
+mp-8883     GaAs-wz  0.5161  0.2154        23.4105            29.0603   
+mp-22913    CuBr-zb  0.8783  0.6150         1.4982             2.8286   
+mp-1265      MgO-rs  0.1084  0.0196        48.8818            47.9311   
+mp-24721     RbH-rs  0.6302  0.5815         2.3660             4.3058   
+mp-1008559    BP-wz  0.5455  0.3888       251.3380           372.6256   
+mp-406      CdTe-zb  0.5960  0.1322         7.8659             6.8908   
+mp-10695     ZnS-zb  0.3409  0.1531        39.6740            34.0310   
+mp-682       NaF-rs  0.2238  0.1292        20.2562            23.0548   
+no-mp-4      BeS-wz  0.3807  0.2739        92.7466           122.1758   
+mp-569346    CuI-wz  0.7008  0.1955         8.1378             6.6883   
+mp-13033    MgTe-zb  0.7078  0.6408        31.2481            16.0828   
+mp-2172     AlAs-zb  0.8049  0.6474       172.9614            88.3701   
+mp-19717    PbTe-rs  0.5143  0.2038         1.2074             0.9841   
+mp-463        KF-rs  0.4834  0.3293         4.9105             6.8460   
+mp-8882      GaP-wz  0.4844  0.0473       103.3225            98.5531   
+mp-966800    InP-wz  0.6348  0.1924        62.7836            76.1462   
+mp-1156     GaSb-zb  0.5730  0.4363        22.5517            35.1349   
+mp-22905    LiCl-rs  0.3516  0.0700         3.4038             3.6507   
+mp-1672      CaS-rs  0.2497  0.1433        23.6282            27.2761   
+mp-8880      AlP-wz  0.4070  0.1898        65.0543            78.6923   
+mp-10044     BAs-zb  0.5456  0.5226       736.5576          1257.6942   
+mp-20305    InAs-zb  0.3740  0.1236        24.6952            21.8216   
+mp-2201     PbSe-rs  0.6305  0.4343         1.3597             0.8745   
+mp-23870     NaH-rs  0.3214  0.2728        11.9268            15.6951   
+no-mp-3     BeSe-wz  0.4582  0.4112        53.1182            80.6115   
+mp-8062      SiC-zb  0.2278  0.0218       375.9704           367.8729   
+mp-1190     ZnSe-zb  0.5849  0.4427        24.8080            15.8165   
+mp-22903     RbI-rs  1.9562  1.9561         0.0198             1.7878   
+mp-1500      BaS-rs  0.6670  0.2582         4.6973             6.0901   
+mp-1007661  InSb-wz  0.7677  0.1896        12.7560            10.5469   
+mp-422       BeS-zb  0.3172  0.1348       127.9443           146.4423   
+mp-22895     CuI-zb  0.6290  0.2604         9.0984             7.0023   
+mp-23193     KCl-rs  0.3734  0.0155         6.2415             6.1454   
+mp-7631      SiC-wz  0.1828  0.0687       403.3627           376.5864   
+mp-380      ZnSe-wz  0.5676  0.3208        21.2905            15.4053   
+no-mp-2      CuH-zb  0.7320  0.4117        22.4960            14.8162   
+mp-1700      AlN-zb  0.1525  0.0271       223.6306           217.6469   
+mp-1784      CsF-rs  0.6654  0.3877         1.0836             1.6047   
+mp-22862    NaCl-rs  0.3195  0.1806         6.0185             7.2135   
+mp-580941    AgI-wz  0.8322  0.1358         1.4755             1.6905   
+mp-20411     InN-zb  0.3187  0.2883        73.3016            97.9891   
+mp-22914    CuCl-zb  0.7909  0.7445         0.6924             1.5136   
+mp-22867    RbBr-rs  1.5705  1.5579         0.3924             3.1576   
+mp-1070     CdSe-wz  0.5357  0.0624        11.5061            10.8100   
+mp-2653       BN-wz  0.0924  0.0170       579.3182           569.5447   
+mp-252      BeTe-zb  0.4607  0.1830        66.7432            80.1883   
+mp-2534     GaAs-zb  0.3452  0.1474        27.7313            32.1448   
+mp-24084      KH-rs  0.3222  0.1881         6.8672             8.2932   
+mp-1519     CaTe-rs  0.2440  0.0646         8.3803             8.9394   
+mp-1018059  GaSb-wz  0.6297  0.2696        18.0719            23.7022   
+mp-2691     CdSe-zb  0.5118  0.2773        15.4195            11.6640   
+mp-1639       BN-zb  0.1019  0.0041       658.6228           655.9004   
+mp-1415     CaSe-rs  0.2791  0.2389        11.9822            15.2337   
+mp-23268     NaI-rs  0.6046  0.3807         1.0993             1.6161   
+mp-2133      ZnO-wz  0.1803  0.0125        51.2316            51.8763   
+mp-2490      GaP-zb  0.5492  0.3710       134.6942            92.5425   
+mp-20351     InP-zb  0.4234  0.0343        77.0122            79.7003   
+mp-1132      CdO-rs  0.5309  0.1909         6.5396             7.9195   
+mp-2605      CaO-rs  0.1357  0.0069        23.7493            23.5857   
+mp-12779    CdTe-wz  0.7737  0.2491         7.5800             5.9008   
+mp-561286    ZnS-wz  0.3772  0.1174        33.5555            37.7411   
+mp-2624     AlSb-zb  0.8283  0.2857       106.6402            79.9804   
+mp-1138      LiF-rs  0.1976  0.0543        13.3967            14.1451   
+mp-22922    AgCl-rs  0.3502  0.2061         0.4289             0.5274   
+mp-672       CdS-wz  0.4577  0.2662        14.9002            19.4747   
+mp-804       GaN-wz  0.1589  0.0591       170.0086           180.3652   
+mp-1986      ZnO-zb  0.1447  0.0754        58.1367            53.9131   
+mp-1000     BaTe-rs  1.8970  1.8963         0.2336             8.7759   
+mp-22916    NaBr-rs  0.6546  0.6365         1.5265             2.9518   
+mp-24093     CuH-wz  0.6753  0.1165         8.9322             7.9492   
+mp-661       AlN-wz  0.1375  0.0160       238.1557           234.3662   
+mp-1479       BP-zb  0.4956  0.4091       265.1424           401.5107   
+mp-22899     LiI-rs  0.9031  0.7754         0.6184             1.4015   
+mp-11718     RbF-rs  0.5397  0.4895         1.8915             3.1177   
+no-mp-1     CuBr-wz  0.7845  0.5468         1.3477             2.3619   
+mp-2469      CdS-zb  0.3532  0.2073        17.5420            21.5979   
+mp-830       GaN-zb  0.1980  0.0912       148.6691           162.8771   
+mp-23259    LiBr-rs  0.4058  0.2991         1.3526             1.8282   
+mp-1342      BaO-rs  0.3477  0.2540         2.3556             3.0410   
+mp-1018100  AlSb-wz  0.9657  0.4248        90.6117            58.8637   
+mp-1778      BeO-zb  0.1232  0.0671       335.0167           358.2733   
+mp-2176     ZnTe-zb  0.5780  0.0784        17.3005            18.7122   
+mp-23251     KBr-rs  0.9993  0.9490         0.9101             2.5537   
+mp-22898      KI-rs  2.0000  2.0000            NaN             1.4035   
+mp-984718    BAs-wz  0.7698  0.7052       527.8874          1102.8709   
+mp-1007652  InAs-wz  0.5607  0.0253        19.8730            20.3819   
+mp-22925     AgI-zb  0.4826  0.0674         2.2002             2.3537   
+mp-1253     BaSe-rs  1.6016  1.5954         1.0025             8.9083   
+mp-22205     InN-wz  0.4492  0.4379        74.9975           117.0513   
+mp-1184046  CuCl-wz  0.7520  0.5045         0.7450             1.2477   
+mp-20012    InSb-zb  0.6043  0.0716        14.3834            13.3893   
+mp-23231    AgBr-rs  0.3986  0.0168         0.4441             0.4367   
+mp-21276     PbS-rs  0.6084  0.3536         2.0229             1.4150   
+mp-1039     MgTe-wz  0.6468  0.5236        22.1737            12.9730   
+mp-8881     AlAs-wz  0.8384  0.6062       140.7397            75.2686   
+mp-1550      AlP-zb  0.3566  0.1635        73.2613            86.3081   
+
+            imaginary_freqs errors  SRME_failed  
+mp_id                                            
+mp-2472               False     []        False  
+mp-2542               False     []        False  
+mp-8884               False     []        False  
+mp-1541               False     []        False  
+mp-23295              False     []        False  
+mp-23703              False     []        False  
+mp-1183441            False     []        False  
+mp-8883               False     []        False  
+mp-22913              False     []        False  
+mp-1265               False     []        False  
+mp-24721              False     []        False  
+mp-1008559            False     []        False  
+mp-406                False     []        False  
+mp-10695              False     []        False  
+mp-682                False     []        False  
+no-mp-4               False     []        False  
+mp-569346             False     []        False  
+mp-13033              False     []        False  
+mp-2172               False     []        False  
+mp-19717              False     []        False  
+mp-463                False     []        False  
+mp-8882               False     []        False  
+mp-966800             False     []        False  
+mp-1156               False     []        False  
+mp-22905              False     []        False  
+mp-1672               False     []        False  
+mp-8880               False     []        False  
+mp-10044              False     []        False  
+mp-20305              False     []        False  
+mp-2201               False     []        False  
+mp-23870              False     []        False  
+no-mp-3               False     []        False  
+mp-8062               False     []        False  
+mp-1190               False     []        False  
+mp-22903              False     []        False  
+mp-1500               False     []        False  
+mp-1007661            False     []        False  
+mp-422                False     []        False  
+mp-22895              False     []        False  
+mp-23193              False     []        False  
+mp-7631               False     []        False  
+mp-380                False     []        False  
+no-mp-2               False     []        False  
+mp-1700               False     []        False  
+mp-1784               False     []        False  
+mp-22862              False     []        False  
+mp-580941             False     []        False  
+mp-20411              False     []        False  
+mp-22914              False     []        False  
+mp-22867              False     []        False  
+mp-1070               False     []        False  
+mp-2653               False     []        False  
+mp-252                False     []        False  
+mp-2534               False     []        False  
+mp-24084              False     []        False  
+mp-1519               False     []        False  
+mp-1018059            False     []        False  
+mp-2691               False     []        False  
+mp-1639               False     []        False  
+mp-1415               False     []        False  
+mp-23268              False     []        False  
+mp-2133               False     []        False  
+mp-2490               False     []        False  
+mp-20351              False     []        False  
+mp-1132               False     []        False  
+mp-2605               False     []        False  
+mp-12779              False     []        False  
+mp-561286             False     []        False  
+mp-2624               False     []        False  
+mp-1138               False     []        False  
+mp-22922              False     []        False  
+mp-672                False     []        False  
+mp-804                False     []        False  
+mp-1986               False     []        False  
+mp-1000               False     []        False  
+mp-22916              False     []        False  
+mp-24093              False     []        False  
+mp-661                False     []        False  
+mp-1479               False     []        False  
+mp-22899              False     []        False  
+mp-11718              False     []        False  
+no-mp-1               False     []        False  
+mp-2469               False     []        False  
+mp-830                False     []        False  
+mp-23259              False     []        False  
+mp-1342               False     []        False  
+mp-1018100            False     []        False  
+mp-1778               False     []        False  
+mp-2176               False     []        False  
+mp-23251              False     []        False  
+mp-22898               True     []         True  
+mp-984718             False     []        False  
+mp-1007652            False     []        False  
+mp-22925              False     []        False  
+mp-1253               False     []        False  
+mp-22205              False     []        False  
+mp-1184046            False     []        False  
+mp-20012              False     []        False  
+mp-23231              False     []        False  
+mp-21276              False     []        False  
+mp-1039               False     []        False  
+mp-8881               False     []        False  
+mp-1550               False     []        False  


### PR DESCRIPTION
Thank you developing this benchmarking suite for thermal conductivity! I found it be quite simple and straightforward to use!

Microsoft have recently made some of their MatterSimV1-1M and MatterSimV1-5M models, so I've ran the benchmark with the `MatterSim-v1.0.0-1M ` checkpoint and this PR is to report the results of their model.

```
MODEL: MatterSim
	mean SRME: 0.5545498749591197
	mean SRE: 0.34254858903760177
```